### PR TITLE
chore: update i18n strings for comment input across multiple locales

### DIFF
--- a/src/locales/default/de.json
+++ b/src/locales/default/de.json
@@ -9015,7 +9015,7 @@
     "Uploading": "Hochladen",
     "Start Upload": "Hochladen starten",
     "Select Assets": "Assets auswählen",
-    "|Type your comment...": "|Geben Sie Ihren Kommentar ein...",
+    "Type your comment...": "Geben Sie Ihren Kommentar ein...",
     "E = mc ^ 2": "E = mc ^ 2",
     "Service is unavailable. Please try again": "Dienst nicht verfügbar. Bitte versuchen Sie es erneut",
     "img": "img",

--- a/src/locales/default/en.json
+++ b/src/locales/default/en.json
@@ -9015,7 +9015,7 @@
     "Uploading": "Uploading",
     "Start Upload": "Start Upload",
     "Select Assets": "Select Assets",
-    "|Type your comment...": "|Type your comment...",
+    "Type your comment...": "Type your comment...",
     "E = mc ^ 2": "E = mc ^ 2",
     "Service is unavailable. Please try again": "Service is unavailable. Please try again",
     "img": "img",

--- a/src/locales/default/fr.json
+++ b/src/locales/default/fr.json
@@ -9015,7 +9015,7 @@
     "Uploading": "Téléchargement",
     "Start Upload": "Commencer le téléchargement",
     "Select Assets": "Sélectionner des actifs",
-    "|Type your comment...": "|Tapez votre commentaire...",
+    "Type your comment...": "Tapez votre commentaire...",
     "E = mc ^ 2": "E = mc ^ 2",
     "Service is unavailable. Please try again": "Le service est indisponible. Veuillez réessayer",
     "img": "img",

--- a/src/locales/default/jp.json
+++ b/src/locales/default/jp.json
@@ -9015,7 +9015,7 @@
     "Uploading": "アップロード中",
     "Start Upload": "アップロードを開始",
     "Select Assets": "資産を選択",
-    "|Type your comment...": "|コメントを入力...",
+    "Type your comment...": "コメントを入力...",
     "E = mc ^ 2": "E = mc ^ 2",
     "Service is unavailable. Please try again": "サービスが利用できません。もう一度お試しください",
     "img": "img",

--- a/src/locales/default/pt.json
+++ b/src/locales/default/pt.json
@@ -9015,7 +9015,7 @@
     "Uploading": "Carregando",
     "Start Upload": "Iniciar Upload",
     "Select Assets": "Selecionar Ativos",
-    "|Type your comment...": "|Digite seu comentário...",
+    "Type your comment...": "Digite seu comentário...",
     "E = mc ^ 2": "E = mc ^ 2",
     "Service is unavailable. Please try again": "Serviço indisponível. Por favor, tente novamente",
     "img": "img",


### PR DESCRIPTION
Removed leading pipe character from the "Type your comment..." string in German, English, French, Japanese, and Portuguese locale files for consistency.