### PR TITLE
Escape

### DIFF
--- a/src/locales/default/de.json
+++ b/src/locales/default/de.json
@@ -276,7 +276,7 @@
     "<namespace>.servicebus.windows.net:9093": "<namespace>.servicebus.windows.net:9093",
     "<private {type}>": "<private {type}>",
     "<redash-instance>.<domain>.com": "<redash-instance>.<domain>.com",
-    "<service_account_name>@<project_id>.iam.gserviceaccount.com": "<service_account_name>@<project_id>.iam.gserviceaccount.com",
+    "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com": "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com",
     "<tenant-id>.<region>.qlikcloud.com": "<tenant-id>.<region>.qlikcloud.com",
     "<tenant>.<region>.<provider>.confluent.cloud": "<tenant>.<region>.<provider>.confluent.cloud",
     "<tenant>.<region>.<provider>.confluent.cloud:9092": "<tenant>.<region>.<provider>.confluent.cloud:9092",

--- a/src/locales/default/en.json
+++ b/src/locales/default/en.json
@@ -276,7 +276,7 @@
     "<namespace>.servicebus.windows.net:9093": "<namespace>.servicebus.windows.net:9093",
     "<private {type}>": "<private {type}>",
     "<redash-instance>.<domain>.com": "<redash-instance>.<domain>.com",
-    "<service_account_name>@<project_id>.iam.gserviceaccount.com": "<service_account_name>@<project_id>.iam.gserviceaccount.com",
+    "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com": "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com",
     "<tenant-id>.<region>.qlikcloud.com": "<tenant-id>.<region>.qlikcloud.com",
     "<tenant>.<region>.<provider>.confluent.cloud": "<tenant>.<region>.<provider>.confluent.cloud",
     "<tenant>.<region>.<provider>.confluent.cloud:9092": "<tenant>.<region>.<provider>.confluent.cloud:9092",

--- a/src/locales/default/fr.json
+++ b/src/locales/default/fr.json
@@ -276,7 +276,7 @@
     "<namespace>.servicebus.windows.net:9093": "<namespace>.servicebus.windows.net:9093",
     "<private {type}>": "<private {type}>",
     "<redash-instance>.<domain>.com": "<redash-instance>.<domain>.com",
-    "<service_account_name>@<project_id>.iam.gserviceaccount.com": "<service_account_name>@<project_id>.iam.gserviceaccount.com",
+    "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com": "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com",
     "<tenant-id>.<region>.qlikcloud.com": "<tenant-id>.<region>.qlikcloud.com",
     "<tenant>.<region>.<provider>.confluent.cloud": "<tenant>.<region>.<provider>.confluent.cloud",
     "<tenant>.<region>.<provider>.confluent.cloud:9092": "<tenant>.<region>.<provider>.confluent.cloud:9092",

--- a/src/locales/default/jp.json
+++ b/src/locales/default/jp.json
@@ -276,7 +276,7 @@
     "<namespace>.servicebus.windows.net:9093": "<namespace>.servicebus.windows.net:9093",
     "<private {type}>": "<private {type}>",
     "<redash-instance>.<domain>.com": "<redash-instance>.<domain>.com",
-    "<service_account_name>@<project_id>.iam.gserviceaccount.com": "<service_account_name>@<project_id>.iam.gserviceaccount.com",
+    "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com": "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com",
     "<tenant-id>.<region>.qlikcloud.com": "<tenant-id>.<region>.qlikcloud.com",
     "<tenant>.<region>.<provider>.confluent.cloud": "<tenant>.<region>.<provider>.confluent.cloud",
     "<tenant>.<region>.<provider>.confluent.cloud:9092": "<tenant>.<region>.<provider>.confluent.cloud:9092",

--- a/src/locales/default/pt.json
+++ b/src/locales/default/pt.json
@@ -276,7 +276,7 @@
     "<namespace>.servicebus.windows.net:9093": "<namespace>.servicebus.windows.net:9093",
     "<private {type}>": "<private {type}>",
     "<redash-instance>.<domain>.com": "<redash-instance>.<domain>.com",
-    "<service_account_name>@<project_id>.iam.gserviceaccount.com": "<service_account_name>@<project_id>.iam.gserviceaccount.com",
+    "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com": "<service_account_name>{'@'}<project_id>.iam.gserviceaccount.com",
     "<tenant-id>.<region>.qlikcloud.com": "<tenant-id>.<region>.qlikcloud.com",
     "<tenant>.<region>.<provider>.confluent.cloud": "<tenant>.<region>.<provider>.confluent.cloud",
     "<tenant>.<region>.<provider>.confluent.cloud:9092": "<tenant>.<region>.<provider>.confluent.cloud:9092",


### PR DESCRIPTION
Escaped the "@" symbol in service account placeholders across locale files to ensure proper parsing and avoid conflicts. This update does not introduce any breaking changes and aims to improve the handling of these placeholders across different environments.