### PR TITLE
chore: add secrets: inherit for Slack alert webhook

### DIFF
--- a/.github/workflows/dep-cooldown.yml
+++ b/.github/workflows/dep-cooldown.yml
@@ -22,3 +22,6 @@ jobs:
     uses: atlanhq/.github/.github/workflows/reusable-dep-cooldown.yml@main
     with:
       min-age-days: 7
+    # Forwards the org-level SLACK_DEP_COOLDOWN_WEBHOOK secret to the reusable
+    # workflow so it can post failure alerts to #community-security.
+    secrets: inherit


### PR DESCRIPTION
Forwards the org-level `SLACK_DEP_COOLDOWN_WEBHOOK` secret to the reusable dep-cooldown workflow so failures post to `#community-security`.

When this repo's `cooldown / dep-cooldown` check fails (a PR introduces a dep version published <7 days ago), the alert step in the reusable workflow needs the secret to be forwarded. Without `secrets: inherit`, the alert falls back to a diagnostic warning in the run log instead of posting to Slack.

One-line change. No effect on the cooldown check itself.