### PR TITLE
Remove redundant pipe symbol from locale files

### DIFF
--- a/src/locales/default/de.json
+++ b/src/locales/default/de.json
@@ -16504,7 +16504,6 @@
     "Creation failed": "Erstellung fehlgeschlagen",
     "Suggested assets": "Vorgeschlagene Assets",
     "No assets were proposed.": "Es wurden keine Assets vorgeschlagen.",
-    "|": "|",
     "›": "›",
     "Approve & Create": "Genehmigen & Erstellen",
     "Share your experience": "Teile deine Erfahrung",

--- a/src/locales/default/en.json
+++ b/src/locales/default/en.json
@@ -16504,7 +16504,6 @@
     "Creation failed": "Creation failed",
     "Suggested assets": "Suggested assets",
     "No assets were proposed.": "No assets were proposed.",
-    "|": "|",
     "›": "›",
     "Approve & Create": "Approve & Create",
     "Share your experience": "Share your experience",

--- a/src/locales/default/es.json
+++ b/src/locales/default/es.json
@@ -16504,7 +16504,6 @@
     "Creation failed": "La creación falló",
     "Suggested assets": "Activos sugeridos",
     "No assets were proposed.": "No se propusieron activos.",
-    "|": "|",
     "›": "›",
     "Approve & Create": "Aprobar y Crear",
     "Share your experience": "Comparte tu experiencia",

--- a/src/locales/default/fr.json
+++ b/src/locales/default/fr.json
@@ -16504,7 +16504,6 @@
     "Creation failed": "Échec de la création",
     "Suggested assets": "Actifs suggérés",
     "No assets were proposed.": "Aucun actif n'a été proposé.",
-    "|": "|",
     "›": "›",
     "Approve & Create": "Approuver et créer",
     "Share your experience": "Partagez votre expérience",

--- a/src/locales/default/jp.json
+++ b/src/locales/default/jp.json
@@ -16504,7 +16504,6 @@
     "Creation failed": "作成に失敗しました",
     "Suggested assets": "提案されたアセット",
     "No assets were proposed.": "アセットは提案されませんでした。",
-    "|": "|",
     "›": "›",
     "Approve & Create": "承認して作成",
     "Share your experience": "あなたの体験を共有してください",

--- a/src/locales/default/ko.json
+++ b/src/locales/default/ko.json
@@ -16504,7 +16504,6 @@
     "Creation failed": "생성 실패",
     "Suggested assets": "추천 자산",
     "No assets were proposed.": "제안된 자산이 없습니다.",
-    "|": "|",
     "›": "›",
     "Approve & Create": "승인 및 생성",
     "Share your experience": "경험을 공유하세요",

--- a/src/locales/default/pt.json
+++ b/src/locales/default/pt.json
@@ -16504,7 +16504,6 @@
     "Creation failed": "Falha na criação",
     "Suggested assets": "Ativos sugeridos",
     "No assets were proposed.": "Nenhum ativo foi proposto.",
-    "|": "|",
     "›": "›",
     "Approve & Create": "Aprovar e Criar",
     "Share your experience": "Compartilhe sua experiência",


### PR DESCRIPTION
### Description
This pull request removes an unnecessary pipe (`|`) symbol from various locale files to improve readability and maintain consistency.

### Checklist
- [ ] Tests are added or updated to cover the changes.
- [ ] Documentation is updated accordingly.
- [ ] Changes are tested locally.