### PR TITLE
feat: extract i18n strings from facelift branch + fix branch-exists CI failure

### DIFF
--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -20,6 +20,9 @@ env:
     BASE_BRANCH: 'main'
     FRONTEND_REPO: 'atlanhq/atlan-frontend'
     FRONTEND_BRANCH: ${{ github.event.client_payload.frontend-branch || github.event.inputs.frontend-branch || 'develop' }}
+    # Second prod line. PRs merged directly into facelift bypass develop, so its
+    # strings must be scanned separately or they never get extracted/translated.
+    FACELIFT_BRANCH: 'facelift'
 
 jobs:
     extract-and-translate:
@@ -31,18 +34,18 @@ jobs:
               with:
                 ref: ${{ env.BASE_BRANCH }}
 
-            # Now checkout the i18n repo
-            - name: Check if branch exists in i18n repo
-              id: check-branch-exists
-              uses: GuillaumeFalourd/branch-exists@v1.1
-              with:
-                  branch: ${{ env.BRANCH_NAME }}
-
+            # Guard against a stale automated branch left by a prior run. Uses
+            # git ls-remote against the already-authenticated origin instead of a
+            # third-party action whose nested checkout duplicated the Authorization
+            # header and broke fetch with HTTP 400.
             - name: Fail if branch already exists
-              if: ${{ steps.check-branch-exists.outputs.exists == 'true' && env.BRANCH_NAME == 'automated-i18n' }}
+              if: ${{ env.BRANCH_NAME == 'automated-i18n' }}
               run: |
-                echo "::error::The branch '${{ env.BRANCH_NAME }}' already exists. Please delete or merge the existing branch before running this workflow again."
-                exit 1
+                if git ls-remote --heads origin "$BRANCH_NAME" | grep -qE "refs/heads/${BRANCH_NAME}$"; then
+                  echo "::error::The branch '$BRANCH_NAME' already exists. Please delete or merge the existing branch before running this workflow again."
+                  exit 1
+                fi
+                echo "Branch '$BRANCH_NAME' does not exist. Proceeding."
 
             - name: Create & checkout branch in i18n repo
               run: git checkout $BASE_BRANCH && git checkout -b $BRANCH_NAME
@@ -68,20 +71,35 @@ jobs:
               env:
                 ORG_PAT_GITHUB: ${{ secrets.ORG_PAT_GITHUB }}
 
-            # First checkout the frontend repo to scan for new strings
+            # Checkout the primary frontend branch (develop, or the manually
+            # dispatched branch) to scan for new strings.
             - name: Checkout frontend repository
               uses: actions/checkout@v6
               with:
                 repository: ${{ env.FRONTEND_REPO }}
                 token: ${{ secrets.ORG_PAT_GITHUB }}
-                path: frontend
+                path: frontend/develop
                 ref: ${{ env.FRONTEND_BRANCH }}
+
+            # Also checkout the facelift prod branch so its strings get extracted.
+            # Skipped only when a specific non-default branch is dispatched manually.
+            - name: Checkout frontend facelift branch
+              if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.frontend-branch == 'develop' }}
+              uses: actions/checkout@v6
+              with:
+                repository: ${{ env.FRONTEND_REPO }}
+                token: ${{ secrets.ORG_PAT_GITHUB }}
+                path: frontend/facelift
+                ref: ${{ env.FACELIFT_BRANCH }}
 
             - name: Run translation script
               run: node scripts/translationScript.mjs
               env:
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
                   BASE_DIRECTORY: ${{ github.workspace }}
+                  # Glob over every checked-out branch dir (frontend/develop,
+                  # frontend/facelift) so missing keys from both prod lines union.
+                  FRONTEND_GLOB: './frontend/*/src/**/*.?(js|vue|ts)'
 
             - name: Run prettier
               run: pnpm prettier --write src/locales/**/*.json

--- a/scripts/translationScript.mjs
+++ b/scripts/translationScript.mjs
@@ -407,7 +407,7 @@ async function synchronizeLocaleFiles(allLocales) {
 
     console.log('Creating I18N report with vue-i18n-extract...')
     const report = await VueI18NExtract.createI18NReport({
-        vueFiles: `./frontend/src/**/*.?(js|vue|ts)`,
+        vueFiles: process.env.FRONTEND_GLOB || `./frontend/src/**/*.?(js|vue|ts)`,
         languageFiles: `${BASE_DIRECTORY}/src/locales/default/*.json`,
     })
 


### PR DESCRIPTION
## Problem

atlan-frontend now has two prod branches: `main` (via develop → staging → main) and `facelift`. The i18n extraction workflow only scanned `atlan-frontend@develop`, so:

- `main` line — covered (its strings pass through develop first).
- `facelift` — **not** covered. PRs merged directly into facelift bypass develop, so their new `t('...')` strings were never extracted or translated.

A second, unrelated failure was blocking the workflow entirely: the `Check if branch exists` step (third-party `GuillaumeFalourd/branch-exists@v1.1`) ran a nested checkout that duplicated the `Authorization` header → `remote: Duplicate header: "Authorization"` → HTTP 400. ([failing run](https://github.com/atlanhq/i18n/actions/runs/28211940148/job/83574941094))

## Changes

**`i18n.yaml`**
- Check out `develop` → `frontend/develop` and `facelift` → `frontend/facelift`. facelift checkout skipped only when a specific non-`develop` branch is dispatched manually.
- `FRONTEND_GLOB=./frontend/*/src/**/*.?(js|vue|ts)` — scans both trees in one run; missing keys union into a single PR to `main`.
- Replace `GuillaumeFalourd/branch-exists@v1.1` with a native `git ls-remote --heads` check (matches the idiom in atlan-frontend `receive-typedef-updates.yml`). Fixes the HTTP 400 and drops an unpinned third-party action.

**`translationScript.mjs`**
- Extraction glob now reads `FRONTEND_GLOB` env, defaulting to the existing path. Local `npm run translate` unchanged.

## Why this is safe

Keys equal their English source string (`en.json` maps `path → path`), so unioning facelift's strings into `main` can only add keys — no collisions. Unused keys on the main frontend are harmless.

## End-to-end for facelift

1. This workflow translates facelift strings into i18n `main`.
2. `notify-frontend` → frontend `update-i18n.yaml` bumps **main's** lockfile.
3. Weekly `facelift-sync` merges main → facelift, reconciling the lockfile.

No frontend-side change needed — both prod branches already consume `@atlanhq/i18n#main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)