### PR TITLE
fix(locales): escape '@' in you@company.com so vue-i18n can compile it

### DIFF
--- a/src/locales/default/de.json
+++ b/src/locales/default/de.json
@@ -17337,7 +17337,7 @@
     "Confluence": "Confluence",
     "Base URL": "Basis-URL",
     "https://your-org.atlassian.net": "https://your-org.atlassian.net",
-    "you@company.com": "you@company.com",
+    "you@company.com": "you{'@'}company.com",
     "Atlassian API token": "Atlassian API-Token",
     "HiBob": "HiBob",
     "Service ID": "Service-ID",

--- a/src/locales/default/en.json
+++ b/src/locales/default/en.json
@@ -17337,7 +17337,7 @@
     "Confluence": "Confluence",
     "Base URL": "Base URL",
     "https://your-org.atlassian.net": "https://your-org.atlassian.net",
-    "you@company.com": "you@company.com",
+    "you@company.com": "you{'@'}company.com",
     "Atlassian API token": "Atlassian API token",
     "HiBob": "HiBob",
     "Service ID": "Service ID",

--- a/src/locales/default/es.json
+++ b/src/locales/default/es.json
@@ -17337,7 +17337,7 @@
     "Confluence": "Confluence",
     "Base URL": "URL base",
     "https://your-org.atlassian.net": "https://your-org.atlassian.net",
-    "you@company.com": "you@company.com",
+    "you@company.com": "you{'@'}company.com",
     "Atlassian API token": "Token de API de Atlassian",
     "HiBob": "HiBob",
     "Service ID": "ID del servicio",

--- a/src/locales/default/fr.json
+++ b/src/locales/default/fr.json
@@ -17337,7 +17337,7 @@
     "Confluence": "Confluence",
     "Base URL": "URL de base",
     "https://your-org.atlassian.net": "https://your-org.atlassian.net",
-    "you@company.com": "you@company.com",
+    "you@company.com": "you{'@'}company.com",
     "Atlassian API token": "Jeton API Atlassian",
     "HiBob": "HiBob",
     "Service ID": "ID de service",

--- a/src/locales/default/jp.json
+++ b/src/locales/default/jp.json
@@ -17337,7 +17337,7 @@
     "Confluence": "コンフルエンス",
     "Base URL": "ベースURL",
     "https://your-org.atlassian.net": "https://your-org.atlassian.net",
-    "you@company.com": "you@company.com",
+    "you@company.com": "you{'@'}company.com",
     "Atlassian API token": "アトラシアンAPIトークン",
     "HiBob": "ハイボブ",
     "Service ID": "サービスID",

--- a/src/locales/default/ko.json
+++ b/src/locales/default/ko.json
@@ -17337,7 +17337,7 @@
     "Confluence": "Confluence",
     "Base URL": "기본 URL",
     "https://your-org.atlassian.net": "https://your-org.atlassian.net",
-    "you@company.com": "you@company.com",
+    "you@company.com": "you{'@'}company.com",
     "Atlassian API token": "Atlassian API 토큰",
     "HiBob": "HiBob",
     "Service ID": "서비스 ID",

--- a/src/locales/default/pt.json
+++ b/src/locales/default/pt.json
@@ -17337,7 +17337,7 @@
     "Confluence": "Confluence",
     "Base URL": "URL base",
     "https://your-org.atlassian.net": "https://your-org.atlassian.net",
-    "you@company.com": "you@company.com",
+    "you@company.com": "you{'@'}company.com",
     "Atlassian API token": "Token da API Atlassian",
     "HiBob": "HiBob",
     "Service ID": "ID do serviço",


### PR DESCRIPTION
## What

Escape the `@` in the `you@company.com` locale value so the vue-i18n message compiler can parse it.

## Why

In vue-i18n message syntax, `@` starts a [linked-message](https://vue-i18n.intlify.dev/guide/essentials/syntax.html#linked-messages) reference (`@:key`, `@.modifier:key`). A bare `@` followed by text that isn't a valid link makes the compiler throw `INVALID_LINKED_FORMAT (error code: 10)`.

The value `you@company.com` is read as `@company...` and fails to compile:

```
[unplugin-vue-i18n] Invalid linked format (error code: 10) in .../src/locales/default/de.json
```

Any consumer that compiles these locale sources eagerly (e.g. `@intlify/unplugin-vue-i18n/messages`) fails hard on the first such string. It's also a latent runtime bug: the key throws whenever it's actually rendered, in any locale.

## Fix

Escape the literal `@` as `{'@'}` — the convention already used elsewhere in these files (e.g. `support{'@'}atlan.com`). It renders as `you@company.com` unchanged.

```diff
-    "you@company.com": "you@company.com",
+    "you@company.com": "you{'@'}company.com",
```

Only the value is escaped (keys aren't compiled). Applied to the 7 locales that carry the string (`en, de, es, fr, jp, ko, pt`; `dprod` doesn't have it).

## Verification

Ran the exact `@intlify/bundle-utils` `generateJSON` codegen path (`jit: true`) over all 8 default locales — every one compiles clean (`INVALID_LINKED_FORMAT` count: 0). Before the fix, `en.json` and `de.json` failed on `you@company.com`.

## Related

Companion PR on the consumer side hardens the test path so a single malformed locale string can't take down the whole suite: atlanhq/atlan-frontend#30220.
